### PR TITLE
Page and revision author

### DIFF
--- a/lib/models/page.rb
+++ b/lib/models/page.rb
@@ -1,6 +1,7 @@
 class Page < Sequel::Model
 
   one_to_many :revisions
+  many_to_one :author, class: :User
 
   def before_create
     self.slug = Title.new(self.title).slug

--- a/lib/models/revision.rb
+++ b/lib/models/revision.rb
@@ -1,6 +1,7 @@
 class Revision < Sequel::Model
 
   many_to_one :page
+  many_to_one :author, class: :User
 
   def revisions
     self.page.revisions

--- a/lib/models/user.rb
+++ b/lib/models/user.rb
@@ -1,4 +1,8 @@
 class User < Sequel::Model
+
+  one_to_many :pages
+  one_to_many :revision
+
   def before_save
     self.created_on ||= Time.now
     super

--- a/migrations/13_page_and_revision_author.rb
+++ b/migrations/13_page_and_revision_author.rb
@@ -1,0 +1,16 @@
+Sequel.migration do
+  change do
+    alter_table(:pages) do
+      add_foreign_key :author_id, :users, null: false
+    end
+
+    alter_table(:revisions) do
+      add_foreign_key :author_id, :users, null: false
+    end
+
+    alter_table(:users) do
+      # We're not able to map all old users to GitHub users
+      set_column_allow_null :github_id
+    end
+  end
+end

--- a/views/page/_actions.haml
+++ b/views/page/_actions.haml
@@ -11,3 +11,8 @@
         - unless @page.revision == (@page.revisions.count + 1)
           %a{ href: "/#{@page.slug}/#{@page.revision + 1}"} +
         )
+  %li
+    Senast ändrad
+    = @page.updated_on
+    av
+    = @page.author.login


### PR DESCRIPTION
Unfortunately github_id needs to be nullable

Previously we had updated_by and created_by, I think
author_id is better. The first author is the creator.
