### PR TITLE
Expect Page class from eager loaded hash groups

### DIFF
--- a/test/integration/app_test.rb
+++ b/test/integration/app_test.rb
@@ -30,4 +30,14 @@ class AppTest < Minitest::Test
     get "/"
     assert last_response.ok?
   end
+
+  def test_latest
+    get "/latest"
+    assert last_response.ok?
+  end
+
+  def test_list
+    get "/list"
+    assert last_response.ok?
+  end
 end

--- a/views/page/latest.haml
+++ b/views/page/latest.haml
@@ -4,12 +4,12 @@
   %ul
     - pages.each do |page|
       %li
-        %a{ href: "#{page.fetch(:slug)}" }= page.fetch(:title)
-        = "(#{page.fetch(:revision)})"
+        %a{ href: "#{page.slug}" }= page.title
+        = "(#{page.revision})"
         %span.latest_item_information
-          = "av #{page.fetch(:login)}"
+          = "av #{page.author.login}"
 
-        - unless page.fetch(:comment).to_s.empty?
+        - unless page.comment.to_s.empty?
           %span.latest_item_information
             med kommentaren
-            = %Q("#{page.fetch(:comment)}")
+            = %Q("#{page.comment}")


### PR DESCRIPTION
A basic get spec for "/latest" would have caught this, added "/list" as
well even though it worked.

Close #73