### PR TITLE
Run "bundle install" with --local flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-18.04
+    env:
+      BUNDLE_LOCAL: 1
     steps:
     - uses: actions/checkout@v2
     - uses: dentarg/postgres@v1


### PR DESCRIPTION
> Do not attempt to connect to rubygems.org. Instead, Bundler will use
> the gems already present in Rubygems' cache or in `vendor/cache`

- https://github.com/rubygems/bundler/blob/v1.17.3/man/bundle-install.ronn#options
- https://github.com/rubygems/rubygems/blob/bundler-v2.2.6/bundler/lib/bundler/man/bundle-install.1.ronn#options

> To convert the canonical form to the environment variable form,
> capitalize it, and prepend `BUNDLE_`

- https://github.com/rubygems/bundler/blob/v1.17.3/man/bundle-config.ronn#configuration-keys
- https://github.com/rubygems/rubygems/blob/bundler-v2.2.6/bundler/lib/bundler/man/bundle-config.1.ronn#configuration-keys