### PR TITLE
Do not list concealed pages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,5 @@ Style/FrozenStringLiteralComment:
   Enabled: true
 Style/MutableConstant:
   Enabled: true
+Layout/DotPosition:
+  Enabled: true

--- a/lib/controllers/page_controller.rb
+++ b/lib/controllers/page_controller.rb
@@ -30,19 +30,19 @@ class PageController < BaseController
 
   get '/list' do
     @page_title = "Innehållsförteckning"
-    @page_groups = Page.order(:title_char, :title).
-      with_concealed_if(starkast?).
-      to_hash_groups(:title_char)
+    @page_groups = Page.order(:title_char, :title)
+      .with_concealed_if(starkast?)
+      .to_hash_groups(:title_char)
     haml :index
   end
 
   get '/latest' do
     @page_title = "Senast ändrad"
-    @page_groups = Page.order(:updated_on).reverse.
-      with_concealed_if(starkast?).
-      eager_graph(:author).
-      add_graph_aliases(date: [:pages, :date, Sequel.lit("DATE(updated_on)")]).
-      to_hash_groups(:date)
+    @page_groups = Page.order(:updated_on).reverse
+      .with_concealed_if(starkast?)
+      .eager_graph(:author)
+      .add_graph_aliases(date: [:pages, :date, Sequel.lit("DATE(updated_on)")])
+      .to_hash_groups(:date)
     haml :latest
   end
 

--- a/lib/controllers/page_controller.rb
+++ b/lib/controllers/page_controller.rb
@@ -30,13 +30,16 @@ class PageController < BaseController
 
   get '/list' do
     @page_title = "Innehållsförteckning"
-    @page_groups = Page.order(:title_char, :title).to_hash_groups(:title_char)
+    @page_groups = Page.order(:title_char, :title).
+      with_concealed_if(starkast?).
+      to_hash_groups(:title_char)
     haml :index
   end
 
   get '/latest' do
     @page_title = "Senast ändrad"
     @page_groups = Page.order(:updated_on).reverse.
+      with_concealed_if(starkast?).
       eager_graph(:author).
       add_graph_aliases(date: [:pages, :date, Sequel.lit("DATE(updated_on)")]).
       to_hash_groups(:date)
@@ -45,7 +48,7 @@ class PageController < BaseController
 
   get '/search' do
     @page_title = "Sökresultat"
-    @pages = Page.search(params[:q])
+    @pages = Page.with_concealed_if(starkast?).search(params[:q])
     @q = params[:q]
 
     case @pages.count
@@ -85,7 +88,7 @@ class PageController < BaseController
   end
 
   get '/:slug/edit' do
-    @page = Page.find(slug: slug)
+    @page = Page.with_concealed_if(starkast?).find(slug: slug)
     @page_title = "Ändrar #{@page.title}"
     restrict_concealed(@page)
     haml :edit

--- a/lib/models/page.rb
+++ b/lib/models/page.rb
@@ -5,7 +5,7 @@ class Page < Sequel::Model
   one_to_many :revisions
   many_to_one :author, class: :User
 
-  SEARCH_IN_COLUMNS = %i(title content description)
+  SEARCH_IN_COLUMNS = %i(title content description).freeze
 
   dataset_module do
     def with_concealed_if(allowed_to_see_concealed)

--- a/lib/models/page.rb
+++ b/lib/models/page.rb
@@ -9,11 +9,9 @@ class Page < Sequel::Model
 
   dataset_module do
     def with_concealed_if(allowed_to_see_concealed)
-      if allowed_to_see_concealed
-        self
-      else
-        self.exclude(concealed: true)
-      end
+      return self if allowed_to_see_concealed
+
+      self.exclude(concealed: true)
     end
 
     def search(query)

--- a/test/integration/app_concealed_pages_test.rb
+++ b/test/integration/app_concealed_pages_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../integration_test_helper"
+
+class AppConcealedPagesTest < Minitest::Test
+  include Rack::Test::Methods
+
+  OUTER_APP = Rack::Builder.parse_file("config.ru").first
+
+  def app
+    OUTER_APP
+  end
+
+  def setup
+    user = User.create(email: "test@test")
+    Page.create(title: "Concealed", author: user, concealed: true)
+  end
+
+  def teardown
+    Page[title: "Concealed"].destroy
+    User[email: "test@test"].destroy
+  end
+
+  def login_as_starkast
+    env "rack.session", { login: "not used", user_id: rand(100), starkast: true }
+  end
+
+  def test_concealed
+    get "/Concealed"
+    follow_redirect!
+    assert last_response.body.include?("Not authorized")
+    assert last_response.ok?
+  end
+
+  def test_concealed_logged_in_as_starkast
+    login_as_starkast
+    get "/Concealed"
+    assert last_response.ok?
+  end
+
+  def test_latest
+    get "/latest"
+    refute last_response.body.include?("Concealed")
+    assert last_response.ok?
+  end
+
+  def test_latest_logged_in_as_starkast
+    login_as_starkast
+    get "/latest"
+    assert last_response.body.include?("Concealed")
+    assert last_response.ok?
+  end
+
+  def test_list
+    get "/list"
+    refute last_response.body.include?("Concealed")
+    assert last_response.ok?
+  end
+
+  def test_list_logged_in_as_starkast
+    login_as_starkast
+    get "/list"
+    assert last_response.body.include?("Concealed")
+    assert last_response.ok?
+  end
+end

--- a/views/page/index.haml
+++ b/views/page/index.haml
@@ -11,5 +11,7 @@
     - pages.each do |page|
       %li
         %a{ href: "#{page.slug}" }= page.title
+        - if page.concealed
+          🔐
         = "(#{page.revision})"
         %span.description= page.description

--- a/views/page/latest.haml
+++ b/views/page/latest.haml
@@ -5,6 +5,8 @@
     - pages.each do |page|
       %li
         %a{ href: "#{page.slug}" }= page.title
+        - if page.concealed
+          🔐
         = "(#{page.revision})"
         %span.latest_item_information
           = "av #{page.author.login}"

--- a/views/page/search.haml
+++ b/views/page/search.haml
@@ -3,6 +3,8 @@
   - @pages.each do |page|
     %li
       %a.page-link{ href: "#{page.slug}" }= page.title
+      - if page.concealed
+        🔐
       %span.description= page.description
 
 :javascript


### PR DESCRIPTION
* Page method `with_concealed_if(bool)` to list concealed pages
* Move Page.search to dataset extension
* Show a lock for concealed pages in lists