### PR TITLE
Use `Sinatra::HamlHelpers`

### DIFF
--- a/lib/controllers/base_controller.rb
+++ b/lib/controllers/base_controller.rb
@@ -1,20 +1,9 @@
 # frozen_string_literal: true
 
-require 'haml/rails_helpers'
 require 'rack-flash'
-require 'sinatra/capture'
+require 'sinatra/haml_helpers'
 require 'sinatra/reloader'
 require 'tilt/haml'
-
-class String
-  def html_safe
-    self
-  end
-
-  def html_safe?
-    true
-  end
-end
 
 class BaseController < Sinatra::Base
   set :views, -> { "views/#{self.name.downcase.sub('controller', '')}" }
@@ -27,8 +16,7 @@ class BaseController < Sinatra::Base
 
   use Rack::Flash
 
-  helpers Haml::RailsHelpers
-  helpers Sinatra::Capture
+  helpers Sinatra::HamlHelpers
 
   configure :development do
     register Sinatra::Reloader

--- a/lib/controllers/base_controller.rb
+++ b/lib/controllers/base_controller.rb
@@ -1,8 +1,20 @@
 # frozen_string_literal: true
 
+require 'haml/rails_helpers'
 require 'rack-flash'
+require 'sinatra/capture'
 require 'sinatra/reloader'
 require 'tilt/haml'
+
+class String
+  def html_safe
+    self
+  end
+
+  def html_safe?
+    true
+  end
+end
 
 class BaseController < Sinatra::Base
   set :views, -> { "views/#{self.name.downcase.sub('controller', '')}" }
@@ -14,6 +26,9 @@ class BaseController < Sinatra::Base
   }]
 
   use Rack::Flash
+
+  helpers Haml::RailsHelpers
+  helpers Sinatra::Capture
 
   configure :development do
     register Sinatra::Reloader

--- a/test/integration/app_test.rb
+++ b/test/integration/app_test.rb
@@ -149,4 +149,29 @@ class AppTest < Minitest::Test
     assert_equal 404, last_response.status
     assert_equal "No code", last_response.body
   end
+
+  def test_footer
+    get "/"
+
+    footer_html = <<~HTML
+      <div id='footer'>
+      <hr>
+      <ul>
+      <li>
+      <a href='/cookies'>Om cookies</a>
+      </li>
+      <li>
+      v42
+      (<a href='https://github.com/Starkast/wikimum/commit/#{AppMetadata.commit}'>#{AppMetadata.short_commit}</a>)
+      </li>
+      <li>
+      <img alt='Starkast' src='/favicon.ico'>
+      </li>
+      </ul>
+
+      </div>
+    HTML
+
+    assert last_response.body.include?(footer_html)
+  end
 end

--- a/views/layouts/_footer.haml
+++ b/views/layouts/_footer.haml
@@ -4,8 +4,7 @@
     %a{ href: "/cookies" } Om cookies
   %li
     = AppMetadata.release_version
-    (
-    %a{ href: "https://github.com/Starkast/wikimum/commit/#{AppMetadata.commit}" }>= AppMetadata.short_commit
-    )
+    != surround "(", ")" do
+      %a{ href: "https://github.com/Starkast/wikimum/commit/#{AppMetadata.commit}" }= AppMetadata.short_commit
   %li
     %img{ src: "/favicon.ico", alt: "Starkast" }


### PR DESCRIPTION
Using `Sinatra::HamlHelpers` from `sinatra-contrib`: https://github.com/sinatra/sinatra/pull/1960

---

See https://github.com/haml/haml/blob/v6.0.5/lib/haml/rails_helpers.rb

Uses the `capture` method from https://github.com/sinatra/sinatra/blob/v3.0.2/sinatra-contrib/lib/sinatra/capture.rb

See also
* https://github.com/rails/rails/blob/v7.0.4/activesupport/lib/active_support/core_ext/string/output_safety.rb
* https://github.com/rails/rails/blob/v7.0.4/actionview/lib/action_view/buffers.rb
* https://github.com/rails/rails/blob/v7.0.4/actionview/lib/action_view/helpers/tag_helper.rb#L413-L422 (`escape_once` defined here, not implemented right now)

Not sure if this is safe or not :)