### PR TITLE
Less wide textarea

### DIFF
--- a/views/page/edit.haml
+++ b/views/page/edit.haml
@@ -19,7 +19,7 @@
       %input#title{ type: :text, name: 'title', maxlength: 74, size: 50, value: @page.title }
 
       %label.block{ for: 'content' } Innehåll
-      %textarea#content{ name: 'content', cols: 84, rows: 20, "hx-post": "/#{@page.slug}/preview", "hx-target": "#preview", "hx-trigger": "keyup changed delay:500ms" }= @page.content
+      %textarea#content{ name: 'content', cols: 78, rows: 20, "hx-post": "/#{@page.slug}/preview", "hx-target": "#preview", "hx-trigger": "keyup changed delay:500ms" }= @page.content
 
       %label.block{ for: 'comment' } Kommentar
       %input#comment{ type: :text, name: 'comment', maxlength: 74, size: 50 }


### PR DESCRIPTION
Avoids overflow when the browser window is 1280px wide.

Before
![wiki-before](https://github.com/user-attachments/assets/1cc67293-3d71-417d-aa9c-8349edad65ea)

After
![wiki-after](https://github.com/user-attachments/assets/626684e6-59c4-43a2-b5e2-d79f11bfa9cc)

