### PR TITLE
Try `ubuntu-slim` GitHub Actions runner

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
     name: Brakeman Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,13 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     needs: ruby
     steps:
       - uses: actions/checkout@v5
       - run: ./bin/docker-test
   ruby:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     env:
       BUNDLE_LOCAL: 1
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: ruby
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v5
       - run: ./bin/docker-test
   ruby:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     env:
       BUNDLE_LOCAL: 1
     steps:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   preview-psql:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     env:
       PREVIEW_DATABASE_URL: "${{ secrets.PREVIEW_DATABASE_URL }}"
     steps:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5

--- a/.github/workflows/gem-compare.yml
+++ b/.github/workflows/gem-compare.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   compare:
     if: github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/bundler/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: dentarg/gem-compare@v1
         with:


### PR DESCRIPTION
I'm curious how good it is.

https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/

> These runners have one vCPU and 5 GBs RAM. When using these runners,
> your actions workflows execute inside of a container rather than a
> dedicated VM instance, enabling cost-effective, performant execution of
> automation tasks across GitHub. Each container provides hypervisor level
> 2 isolation, and the container is automatically decomissioned when a job
> is completed.
>
> Jobs that use this runner type are limited to 15 minutes of execution
> time. Jobs exceeding this limit will be terminated and fail.