### PR TITLE
Scroll selected element into view during j/k navigation

### DIFF
--- a/views/page/_keyboard_navigation.haml
+++ b/views/page/_keyboard_navigation.haml
@@ -5,6 +5,7 @@
     }
     function selectElement(element) {
       element.id = "navigation-selected";
+      element.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
       return true;
     }
     function deselectElement(element) {


### PR DESCRIPTION
Keyboard navigation now scrolls the page to keep the selected search result visible

Tested in Safari and Chrome

Close #36