### PR TITLE
Select only needed columns on /list and /latest

### DIFF
--- a/lib/controllers/page_controller.rb
+++ b/lib/controllers/page_controller.rb
@@ -30,7 +30,9 @@ class PageController < BaseController
 
   get '/list' do
     @page_title = "Innehållsförteckning"
-    @page_groups = Page.order(:title_char, :title)
+    @page_groups = Page
+      .select(:id, :slug, :title, :title_char, :revision, :concealed, :description)
+      .order(:title_char, :title)
       .with_concealed_if(starkast?)
       .to_hash_groups(:title_char)
     haml :index
@@ -38,7 +40,9 @@ class PageController < BaseController
 
   get '/latest' do
     @page_title = "Senast ändrad"
-    @page_groups = Page.order(:updated_on).reverse
+    @page_groups = Page
+      .select(:id, :slug, :title, :revision, :concealed, :comment, :updated_on, :author_id)
+      .order(:updated_on).reverse
       .with_concealed_if(starkast?)
       .eager_graph(:author)
       .add_graph_aliases(date: [:pages, :date, Sequel.lit("DATE(updated_on)")])

--- a/test/integration/app_not_logged_in_test.rb
+++ b/test/integration/app_not_logged_in_test.rb
@@ -85,8 +85,12 @@ class AppNotLoggedInTest < Minitest::Test
   end
 
   def test_latest
+    @page.this.update(comment: "Important note", revision: 7)
     get "/latest"
     assert last_response.body.include?("<h2>#{Time.now.to_date}</h2>")
+    assert last_response.body.include?("av #{@user.login}")
+    assert last_response.body.include?("(7)")
+    assert last_response.body.include?("Important note")
     assert last_response.ok?
   end
 


### PR DESCRIPTION
These views render a handful of fields per page (slug, title, revision, concealed, description/comment, updated_on), but the queries did SELECT * and pulled every column, including the TEXT bodies in `content` and `compiled_content`.

Measured on a 2000-page bench with ~15 KB content per page (143 MB table size):

    full SELECT *:  553 ms/req
    thin SELECT:     20 ms/req     (~27x)