### PR TITLE
Mark /search results as noindex for search engines

### DIFF
--- a/lib/controllers/page_controller.rb
+++ b/lib/controllers/page_controller.rb
@@ -58,6 +58,7 @@ class PageController < BaseController
 
   get '/search' do
     @page_title = "Sökresultat"
+    @noindex = true
     @q = params[:q]
     @pages = Page
       .select(:id, :slug, :title, :concealed, :description)

--- a/test/integration/app_not_logged_in_test.rb
+++ b/test/integration/app_not_logged_in_test.rb
@@ -161,6 +161,17 @@ class AppNotLoggedInTest < Minitest::Test
     other&.destroy
   end
 
+  def test_search_results_are_noindex
+    other_page = Page.create(title: "Test annan sida", author: @user)
+    get "/search?q=Test"
+
+    assert last_response.ok?
+    assert_match(/name=['"]robots['"]/, last_response.body)
+    assert_match(/content=['"]noindex['"]/, last_response.body)
+  ensure
+    other_page&.destroy
+  end
+
   def capture_db_queries
     logger = Logger.new(File::NULL)
     captured = []

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -3,6 +3,8 @@
   %head
     %meta{ 'http-equiv' => 'content-type', content: 'text/html; charset=utf-8' }
     %meta{ name: 'referrer', content: 'same-origin' }
+    - if @noindex
+      %meta{ name: 'robots', content: 'noindex' }
     %title
       = "#{@page_title} - " if @page_title
       Starkast Wiki


### PR DESCRIPTION
Per Google's docs, robots.txt is insufficient to keep pages out of the index — a `noindex` meta tag is required. The /search controller now sets `@noindex` and the layout renders the robots meta tag when set.

Fixes #84