### PR TITLE
Render search view in place when there are no hits

### DIFF
--- a/lib/controllers/page_controller.rb
+++ b/lib/controllers/page_controller.rb
@@ -67,8 +67,8 @@ class PageController < BaseController
 
     case @pages.size
     when 0
-      flash[:notice] = "Din sökning gav inga träffar"
-      redirect request.referrer
+      flash.now[:notice] = "Din sökning gav inga träffar"
+      haml :search
     when 1
       flash[:confirm] = "Din sökning gav bara denna sida som träff"
       redirect @pages.first.slug

--- a/test/integration/app_not_logged_in_test.rb
+++ b/test/integration/app_not_logged_in_test.rb
@@ -161,6 +161,15 @@ class AppNotLoggedInTest < Minitest::Test
     other&.destroy
   end
 
+  def test_search_no_hits_renders_in_place
+    random_query = SecureRandom.hex
+    get "/search", q: random_query
+
+    assert last_response.ok?, "expected 200, got #{last_response.status}"
+    assert last_response.body.include?("Din sökning gav inga träffar")
+    assert last_response.body.include?("Sökresultat")
+  end
+
   def capture_db_queries
     logger = Logger.new(File::NULL)
     captured = []


### PR DESCRIPTION
Previously, a search with zero matches redirected back to the referrer with only a flash notice. The notice was easy to miss and the user lost context of what they searched for.

Now /search renders the search results page in place with a clear "no results" message, so the user can adjust their query without navigating away.

Fixes #35