### PR TITLE
Allow dots in wiki link syntax

### DIFF
--- a/lib/services/markup.rb
+++ b/lib/services/markup.rb
@@ -21,7 +21,7 @@ class MarkdownFilter < HTMLPipeline::TextFilter
 end
 
 class WikiLinkFilter < HTMLPipeline::TextFilter
-  WIKI_LINK_REGEXP = /\[\[(?<link>[\d\w\sÅÄÖåäö:-]{1,35})\]\]/i.freeze
+  WIKI_LINK_REGEXP = /\[\[(?<link>[\d\w\sÅÄÖåäö.:-]{1,35})\]\]/i.freeze
 
   def call
     content = text

--- a/test/unit/markup_test.rb
+++ b/test/unit/markup_test.rb
@@ -32,6 +32,13 @@ class MarkupTest < Minitest::Test
     assert_equal html_output, Markup.to_html(content)
   end
 
+  def test_wiki_link_filter_with_dot_in_link
+    content     = %([[1.2.3]])
+    html_output = %(<p><a href="/1.2.3">1.2.3</a></p>\n)
+
+    assert_equal html_output, Markup.to_html(content)
+  end
+
   def test_wikified_with_markdown
     content     = %([[Server]])
     html_output = %(<p><a href="/Server">Server</a></p>\n)


### PR DESCRIPTION
The `[[...]]` internal link regex excluded `.`, so titles like `[[1.2.3]]` rendered as literal text instead of a link. Add `.` to the allowed character class.

Fixes #608