### PR TITLE
Redirect page slugs with spaces to underscore form

### DIFF
--- a/lib/controllers/page_controller.rb
+++ b/lib/controllers/page_controller.rb
@@ -215,6 +215,9 @@ class PageController < BaseController
   end
 
   get '/:slug' do
+    if params[:slug].include?(" ")
+      redirect "/#{params[:slug].tr(' ', '_')}", 301
+    end
     @page = Page
       .select(:id, :slug, :title, :concealed, :revision, :updated_on, :compiled_content, :author_id)
       .eager_graph(:author)

--- a/test/integration/app_not_logged_in_test.rb
+++ b/test/integration/app_not_logged_in_test.rb
@@ -88,6 +88,13 @@ class AppNotLoggedInTest < Minitest::Test
     assert_equal "/new/#{random_slug}", URI(redirect_location).path
   end
 
+  def test_page_with_space_in_slug_redirects_to_underscore
+    get "/foo%20bar"
+
+    assert_equal 301, last_response.status
+    assert_equal "/foo_bar", URI(last_response["Location"]).path
+  end
+
   def test_new
     get "/new"
 


### PR DESCRIPTION
When visiting a slug containing a literal space (e.g. /Foo Bar, URL-encoded as /Foo%20Bar), 301-redirect to the canonical underscore slug so the browser address bar matches the stored slug. Improves SEO and avoids the previous 302 detour through /new/<slug>.

Fixes #54