### PR TITLE
Cut GET / to one DB query and trim columns

### DIFF
--- a/lib/controllers/page_controller.rb
+++ b/lib/controllers/page_controller.rb
@@ -18,7 +18,12 @@ class PageController < BaseController
   end
 
   get '/' do
-    @page = Page.order(:id).first || Page.new(title: "Förstasidan")
+    @page = Page
+      .select(:id, :slug, :title, :concealed, :revision, :updated_on, :compiled_content, :author_id)
+      .eager_graph(:author)
+      .order(:id)
+      .all
+      .first || Page.new(title: "Förstasidan")
 
     if @page.new? && logged_in?
       redirect "new"

--- a/test/integration/app_not_logged_in_test.rb
+++ b/test/integration/app_not_logged_in_test.rb
@@ -29,6 +29,17 @@ class AppNotLoggedInTest < Minitest::Test
     assert last_response.ok?
   end
 
+  def test_root_uses_one_query_and_renders_author
+    queries = capture_db_queries { get "/" }
+
+    assert last_response.ok?
+    assert_includes last_response.body, @page.title
+    assert_match(/av\s+#{Regexp.escape(@user.login)}/, last_response.body,
+      "expected author login rendered by _actions partial")
+    assert_equal 1, queries.size,
+      "GET / should use one DB query, got #{queries.size}: #{queries.inspect}"
+  end
+
   def test_page
     get "/#{CGI.escape(@page.slug)}"
     assert last_response.body.include?(@page_title)


### PR DESCRIPTION
Same shape as #940 for /:slug — thin SELECT + eager_graph(:author). The Page.new fallback for an empty wiki is left as-is; _actions.haml already guards rendering on `unless @page.new?`.