### PR TITLE
Bound single-row page lookups with LIMIT 1

### DIFF
--- a/lib/controllers/page_controller.rb
+++ b/lib/controllers/page_controller.rb
@@ -22,6 +22,7 @@ class PageController < BaseController
       .select(:id, :slug, :title, :concealed, :revision, :updated_on, :compiled_content, :author_id)
       .eager_graph(:author)
       .order(:id)
+      .limit(1)
       .all
       .first || Page.new(title: "Förstasidan")
 
@@ -218,6 +219,7 @@ class PageController < BaseController
       .select(:id, :slug, :title, :concealed, :revision, :updated_on, :compiled_content, :author_id)
       .eager_graph(:author)
       .where(slug: slug)
+      .limit(1)
       .all
       .first
     redirect "new/#{slug}" unless @page

--- a/test/integration/app_not_logged_in_test.rb
+++ b/test/integration/app_not_logged_in_test.rb
@@ -29,7 +29,12 @@ class AppNotLoggedInTest < Minitest::Test
     assert last_response.ok?
   end
 
-  def test_root_uses_one_query_and_renders_author
+  def test_root_uses_one_bounded_query_and_renders_author
+    # Create extra pages so the route can't accidentally fetch the whole
+    # table — `Page.eager_graph(:author).all.first` without LIMIT would
+    # materialise every page row joined with users in memory.
+    extras = 3.times.map { |i| Page.create(title: "Extra #{i}", author: @user) }
+
     queries = capture_db_queries { get "/" }
 
     assert last_response.ok?
@@ -38,6 +43,10 @@ class AppNotLoggedInTest < Minitest::Test
       "expected author login rendered by _actions partial")
     assert_equal 1, queries.size,
       "GET / should use one DB query, got #{queries.size}: #{queries.inspect}"
+    assert_match(/LIMIT 1\b/i, queries.first,
+      "GET / must bound the page lookup with LIMIT 1, got: #{queries.first.inspect}")
+  ensure
+    extras&.each(&:destroy)
   end
 
   def test_page
@@ -66,6 +75,8 @@ class AppNotLoggedInTest < Minitest::Test
     assert_includes last_response.body, @page_title
     assert_match(/av\s+#{Regexp.escape(@user.login)}/, last_response.body, "expected author login rendered by _actions partial")
     assert_equal 1, queries.size, "GET /:slug should use one DB query, got #{queries.size}: #{queries.inspect}"
+    assert_match(/LIMIT 1\b/i, queries.first,
+      "GET /:slug must bound the page lookup with LIMIT 1, got: #{queries.first.inspect}")
   end
 
   def test_nonexistent_page


### PR DESCRIPTION
PR #941 dropped both the WHERE and the LIMIT from the / query, so the eager_graph dataset fetched every page joined to its author into Ruby before .first picked one. /:slug has the same shape and is only safe today because slug has a UNIQUE constraint — make both explicit.

Local bench against the prod restore:

    /         11.83 ms / 6619 alloc  ->  1.60 ms / 1323 alloc
    /:slug     0.99 ms / 1438 alloc  ->  1.98 ms / 1447 alloc

/:slug is flat as expected (UNIQUE already bounded it). / is 7× faster.

Existing /:slug lock-in extended with a LIMIT 1 SQL assertion; new / lock-in creates extra pages so a missing LIMIT actually fails — both verified red on the prior code.