### PR TITLE
Rename session cookie rack.session -> wikimum_session

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -29,6 +29,7 @@ if App.redirect_to_https?
 end
 
 use Rack::Session::Cookie,
+  key: 'wikimum_session',
   same_site: :lax,
   secret: ENV.fetch('SESSION_SECRET'),
   expire_after: 60 * 60 * 24 * 365

--- a/test/integration/app_not_logged_in_test.rb
+++ b/test/integration/app_not_logged_in_test.rb
@@ -29,6 +29,15 @@ class AppNotLoggedInTest < Minitest::Test
     assert last_response.ok?
   end
 
+  def test_session_cookie_is_named_wikimum_session
+    # Cookie name must be `wikimum_session` (no dot) so nginx in front can
+    # reference it as `$cookie_wikimum_session` for cache-bypass rules.
+    get "/"
+    cookie = last_response.headers["Set-Cookie"].to_s
+    assert_match(/^wikimum_session=/, cookie,
+      "expected wikimum_session= prefix, got: #{cookie.inspect}")
+  end
+
   def test_root_uses_one_bounded_query_and_renders_author
     # Create extra pages so the route can't accidentally fetch the whole
     # table — `Page.eager_graph(:author).all.first` without LIMIT would


### PR DESCRIPTION
The default Rack::Session::Cookie name is `rack.session`. The dot makes it impossible to reference the cookie cleanly as an nginx variable (`$cookie_rack.session` isn't valid syntax), which blocks a future nginx `proxy_cache_bypass $cookie_<name>` rule for the upstream caching plan tracked in the related issue.

Set `key: 'wikimum_session'` so nginx can address it.

Resets current session cookies.