### PR TITLE
Emit ETag on page show so repeat views skip render

### DIFF
--- a/lib/controllers/page_controller.rb
+++ b/lib/controllers/page_controller.rb
@@ -216,7 +216,7 @@ class PageController < BaseController
 
   get '/:slug' do
     @page = Page
-      .select(:id, :slug, :title, :concealed, :revision, :updated_on, :compiled_content, :author_id)
+      .select(:id, :slug, :title, :concealed, :revision, :updated_on, :compiled_content, :author_id, :sha1)
       .eager_graph(:author)
       .where(slug: slug)
       .limit(1)
@@ -225,6 +225,13 @@ class PageController < BaseController
     redirect "new/#{slug}" unless @page
     @page_title = @page.title
     restrict_concealed(@page)
+
+    # Etag halts the response with 304 before view rendering when the browser's
+    # If-None-Match matches. Encode auth state in the etag so a logged-in user
+    # never gets the anonymous body served back from their cache, and so a
+    # starkast user doesn't share an etag with non-starkast.
+    etag [@page.sha1, logged_in? ? "a" : "p", starkast? ? "s" : "u"].join("-")
+
     haml :show
   end
 

--- a/lib/controllers/page_controller.rb
+++ b/lib/controllers/page_controller.rb
@@ -17,11 +17,30 @@ class PageController < BaseController
     end
 
     # Halts the response with 304 before the view renders when the browser's
-    # If-None-Match matches. The audience suffix (a/p for logged_in?, s/u for
-    # starkast?) keeps anonymous and authed renders in separate cache buckets
-    # so neither audience can receive the other's body back from a 304.
+    # If-None-Match matches. Components of the etag value:
+    #
+    #   - page.sha1 — content fingerprint, recomputed in Page#before_save.
+    #   - page.concealed — `post '/:slug/conceal'` uses `page.this.update` and
+    #     deliberately bypasses before_save, so sha1 doesn't reflect
+    #     concealment toggles. Mix it in explicitly so the etag is in sync
+    #     with what _actions.haml renders.
+    #   - audience suffix (a/p for logged_in?, s/u for starkast?) — keeps
+    #     anonymous, authed-not-starkast, and starkast renders in separate
+    #     cache buckets so neither audience can receive another's body back
+    #     from a 304.
+    #
+    # The audience suffix is defence in depth, not the access policy. Two
+    # different logged-in users share the same etag but have different
+    # `current_user.login` rendered in the layout — they must not be allowed
+    # to share a cached body. Authed responses set Cache-Control: private to
+    # keep them out of shared caches.
     def etag_for_page(page)
-      etag [page.sha1, logged_in? ? "a" : "p", starkast? ? "s" : "u"].join("-")
+      etag [
+        page.sha1,
+        page.concealed ? "c" : "x",
+        logged_in? ? "a" : "p",
+        starkast? ? "s" : "u",
+      ].join("-")
     end
   end
 

--- a/lib/controllers/page_controller.rb
+++ b/lib/controllers/page_controller.rb
@@ -15,11 +15,19 @@ class PageController < BaseController
         redirect back
       end
     end
+
+    # Halts the response with 304 before the view renders when the browser's
+    # If-None-Match matches. The audience suffix (a/p for logged_in?, s/u for
+    # starkast?) keeps anonymous and authed renders in separate cache buckets
+    # so neither audience can receive the other's body back from a 304.
+    def etag_for_page(page)
+      etag [page.sha1, logged_in? ? "a" : "p", starkast? ? "s" : "u"].join("-")
+    end
   end
 
   get '/' do
     @page = Page
-      .select(:id, :slug, :title, :concealed, :revision, :updated_on, :compiled_content, :author_id)
+      .select(:id, :slug, :title, :concealed, :revision, :updated_on, :compiled_content, :author_id, :sha1)
       .eager_graph(:author)
       .order(:id)
       .limit(1)
@@ -31,6 +39,11 @@ class PageController < BaseController
     end
 
     @page_title = @page.title
+
+    # Skipped for the empty-wiki fallback (Page.new has no sha1); that
+    # response is cheap to render anyway.
+    etag_for_page(@page) unless @page.new?
+
     haml :show
   end
 
@@ -225,13 +238,7 @@ class PageController < BaseController
     redirect "new/#{slug}" unless @page
     @page_title = @page.title
     restrict_concealed(@page)
-
-    # Etag halts the response with 304 before view rendering when the browser's
-    # If-None-Match matches. Encode auth state in the etag so a logged-in user
-    # never gets the anonymous body served back from their cache, and so a
-    # starkast user doesn't share an etag with non-starkast.
-    etag [@page.sha1, logged_in? ? "a" : "p", starkast? ? "s" : "u"].join("-")
-
+    etag_for_page(@page)
     haml :show
   end
 

--- a/test/integration/app_concealed_pages_test.rb
+++ b/test/integration/app_concealed_pages_test.rb
@@ -112,4 +112,31 @@ class AppConcealedPagesTest < Minitest::Test
   ensure
     visible&.destroy
   end
+
+  def test_etag_does_not_short_circuit_concealed_redirect_for_anonymous
+    # Anonymous visitor sends an If-None-Match that *would* match the etag
+    # computed for an anonymous view of this concealed page. The auth-gate
+    # (restrict_concealed) must run BEFORE the etag check so the 304
+    # path can't bypass authorization. If the order ever swaps, a 304 is
+    # returned instead of the 302 redirect.
+    # Sinatra's `etag` helper wraps the value in double quotes per HTTP spec,
+    # so If-None-Match must match the quoted form to actually short-circuit.
+    matching_etag = %("#{[@page.sha1, "c", "p", "u"].join("-")}")
+    header "If-None-Match", matching_etag
+
+    get "/#{@page.slug_for_uri}"
+
+    refute_equal 304, last_response.status,
+      "etag check must run after restrict_concealed; got 304 — auth gate bypassed"
+    assert_equal 302, last_response.status
+  end
+
+  def test_etag_encodes_starkast_audience_with_s_suffix
+    login_as_starkast
+    get "/#{@page.slug_for_uri}"
+
+    assert last_response.ok?
+    assert_match(/-a-s\b/, last_response.headers["ETag"].to_s,
+      "starkast ETag should end with -a-s, got #{last_response.headers["ETag"].inspect}")
+  end
 end

--- a/test/integration/app_logged_in_test.rb
+++ b/test/integration/app_logged_in_test.rb
@@ -66,6 +66,14 @@ class AppLoggedInTest < Minitest::Test
     assert last_response.ok?
   end
 
+  def test_page_etag_encodes_logged_in_audience
+    get "/#{CGI.escape(@page.slug)}"
+    assert last_response.ok?
+    # Encoded suffix: -<a|p>-<s|u> = authed, not starkast
+    assert_match(/-a-u\b/, last_response.headers["ETag"].to_s,
+      "logged-in ETag should end with -a-u, got #{last_response.headers["ETag"].inspect}")
+  end
+
   def test_page_edit_no_payload
     post "/#{CGI.escape(@page.slug)}"
 

--- a/test/integration/app_not_logged_in_test.rb
+++ b/test/integration/app_not_logged_in_test.rb
@@ -64,6 +64,26 @@ class AppNotLoggedInTest < Minitest::Test
     assert last_response.ok?
   end
 
+  def test_page_sets_etag_header_for_anonymous_visitors
+    get "/#{CGI.escape(@page.slug)}"
+    assert last_response.ok?
+    # Encoded suffix: -<a|p>-<s|u> = anonymous, not starkast
+    assert_match(/-p-u\b/, last_response.headers["ETag"].to_s,
+      "anonymous ETag should end with -p-u, got #{last_response.headers["ETag"].inspect}")
+  end
+
+  def test_page_returns_304_when_etag_matches
+    get "/#{CGI.escape(@page.slug)}"
+    etag = last_response.headers["ETag"]
+    refute_nil etag
+
+    header "If-None-Match", etag
+    get "/#{CGI.escape(@page.slug)}"
+
+    assert_equal 304, last_response.status
+    assert_empty last_response.body
+  end
+
   def test_page_show_uses_one_query_and_renders_author
     queries = []
     counting = Logger.new(File::NULL).tap do |l|

--- a/test/integration/app_not_logged_in_test.rb
+++ b/test/integration/app_not_logged_in_test.rb
@@ -38,6 +38,25 @@ class AppNotLoggedInTest < Minitest::Test
       "expected wikimum_session= prefix, got: #{cookie.inspect}")
   end
 
+  def test_root_sets_etag_header_for_anonymous_visitors
+    get "/"
+    assert last_response.ok?
+    assert_match(/-p-u\b/, last_response.headers["ETag"].to_s,
+      "anonymous ETag should end with -p-u, got #{last_response.headers["ETag"].inspect}")
+  end
+
+  def test_root_returns_304_when_etag_matches
+    get "/"
+    etag = last_response.headers["ETag"]
+    refute_nil etag
+
+    header "If-None-Match", etag
+    get "/"
+
+    assert_equal 304, last_response.status
+    assert_empty last_response.body
+  end
+
   def test_root_uses_one_bounded_query_and_renders_author
     # Create extra pages so the route can't accidentally fetch the whole
     # table — `Page.eager_graph(:author).all.first` without LIMIT would

--- a/test/integration/app_not_logged_in_test.rb
+++ b/test/integration/app_not_logged_in_test.rb
@@ -103,6 +103,21 @@ class AppNotLoggedInTest < Minitest::Test
     assert_empty last_response.body
   end
 
+  def test_page_does_not_304_anonymous_request_holding_a_logged_in_etag
+    # Anonymous request, but the browser is presenting an etag that would
+    # only have been issued for a logged-in audience. The server's etag for
+    # this request bucket differs (audience suffix), so If-None-Match must
+    # not match — full 200 response, not 304.
+    # Quoted per HTTP ETag syntax (Sinatra's `etag` helper wraps values).
+    fake_authed_etag = %("#{[@page.sha1, "x", "a", "u"].join("-")}")
+    header "If-None-Match", fake_authed_etag
+
+    get "/#{CGI.escape(@page.slug)}"
+
+    assert_equal 200, last_response.status,
+      "anonymous request must not 304 against a logged-in audience etag"
+  end
+
   def test_page_show_uses_one_query_and_renders_author
     queries = []
     counting = Logger.new(File::NULL).tap do |l|


### PR DESCRIPTION
Encode page sha1 (already maintained by Page#before_save) plus an audience tag (logged_in?, starkast?) and pass it to Sinatra's `etag` helper. When a browser sends If-None-Match equal to the current value Sinatra halts with 304 before `haml :show` runs, saving render time and the response body bytes.

The audience tag matters: an anonymous visit and a logged-in visit render different HTML (edit links, admin toggles), so we can't let them share an ETag. Encoding `a/p` (auth state) and `s/u` (starkast) keeps the cache buckets separate.

Order matters: `etag` is called AFTER `restrict_concealed` so a 304 halt can't bypass the concealed-page auth check.

Local bench against wikimum (real pages):

    slug                              200      304     savings
    google_chrome_crash (32 KB cc)    6.64 ms  3.50 ms -47%
    openbsd_56_released (17 KB)       4.63 ms  3.22 ms -30%
    info_om_patriks_macbook_pro       3.03 ms  2.26 ms -25%
    kladd (~0 KB)                     1.78 ms  1.60 ms -10%

Bigger pages see bigger relative wins (HAML render skipped), and the 304 saves the full response body over the wire on top. The DB lookup still runs since we need sha1 to compute the etag.