### PR TITLE
Skip session cookie for anonymous responses

### DIFF
--- a/lib/controllers/base_controller.rb
+++ b/lib/controllers/base_controller.rb
@@ -30,6 +30,30 @@ class BaseController < Sinatra::Base
     @page_title = nil
   end
 
+  # Don't write a session cookie back when there's nothing to persist.
+  # The layout reads `session[:login]` via `logged_in?` on every render,
+  # which marks the session as "loaded" and would otherwise make rack-session
+  # write a fresh Set-Cookie for every anonymous response. Set-Cookie blocks
+  # nginx from caching the response, and there's nothing useful in the
+  # cookie when the session hash is empty anyway.
+  # Keys that rack-session and Rack::Flash put in the session even when no
+  # user data exists:
+  #   - "session_id": Sinatra/rack-session inserts this on first access.
+  #   - "__FLASH__":  Rack::Flash seeds an empty Hash on every request.
+  # Treat a session containing only these (and an empty __FLASH__) as empty.
+  SESSION_NOISE_KEYS = %w[session_id __FLASH__].freeze
+
+  after do
+    session_options = request.env["rack.session.options"]
+    next unless session_options
+
+    data = session.to_hash.reject { |k, _| SESSION_NOISE_KEYS.include?(k.to_s) }
+    flash = session["__FLASH__"]
+    has_pending_flash = flash.is_a?(Hash) && flash.any?
+
+    session_options[:skip] = true if data.empty? && !has_pending_flash
+  end
+
   helpers do
     def logged_in?
       session[:login]

--- a/test/integration/app_logged_in_test.rb
+++ b/test/integration/app_logged_in_test.rb
@@ -31,6 +31,15 @@ class AppLoggedInTest < Minitest::Test
     @user.destroy
   end
 
+  def test_logged_in_response_still_sets_session_cookie
+    # Counterpart to test_anonymous_get_does_not_set_a_session_cookie in
+    # app_not_logged_in_test: the skip-empty-session after-filter must NOT
+    # suppress Set-Cookie when the session actually holds login data.
+    get "/"
+    refute_empty last_response.headers["Set-Cookie"].to_s,
+      "logged-in responses must continue to write Set-Cookie"
+  end
+
   def test_create_page
     title = "Foo Bar Åäö"
     post "/new", title:, content: "foo bar baz"

--- a/test/integration/app_not_logged_in_test.rb
+++ b/test/integration/app_not_logged_in_test.rb
@@ -32,10 +32,28 @@ class AppNotLoggedInTest < Minitest::Test
   def test_session_cookie_is_named_wikimum_session
     # Cookie name must be `wikimum_session` (no dot) so nginx in front can
     # reference it as `$cookie_wikimum_session` for cache-bypass rules.
+    # Populate the session so the cookie actually gets written — anonymous
+    # GETs skip Set-Cookie now (see test_anonymous_get_does_not_set_a_session_cookie).
+    env "rack.session", { login: @user.login, user_id: @user.id }
     get "/"
     cookie = last_response.headers["Set-Cookie"].to_s
     assert_match(/^wikimum_session=/, cookie,
       "expected wikimum_session= prefix, got: #{cookie.inspect}")
+  end
+
+  def test_anonymous_get_does_not_set_a_session_cookie
+    # Layout reads `session[:login]` via the `logged_in?` helper, which loads
+    # the session. Rack::Session::Cookie's commit logic then writes Set-Cookie
+    # for every response that touched the session at all. We don't want that
+    # for anonymous responses — both because there is no useful state to
+    # persist and because the Set-Cookie header prevents nginx in front from
+    # caching the response.
+    get "/"
+
+    refute_includes last_response.headers.fetch("Set-Cookie", ""), "rack.session=",
+      "anonymous GET should not write a session cookie"
+    refute_includes last_response.headers.fetch("Set-Cookie", ""), "wikimum_session=",
+      "anonymous GET should not write a session cookie"
   end
 
   def test_root_sets_etag_header_for_anonymous_visitors


### PR DESCRIPTION
Today every response from the app carries a Set-Cookie header for the session cookie, even for anonymous visitors who never log in. That happens because the layout's `logged_in?` helper reads `session[:login]` on every render, which marks the session as "loaded" and triggers Rack::Session::Cookie's commit logic. The cookie is then encoded with just an internal session_id and an empty flash hash — no useful content — but the Set-Cookie header is enough to make nginx refuse to cache the response in the upstream caching plan.

Add a Sinatra `after` filter that flips `rack.session.options[:skip]` to true when the session holds no real data. "Real data" means anything beyond the keys that Sinatra/rack-session and Rack::Flash plant automatically:

  - `session_id` (Sinatra/rack-session bookkeeping)
  - `__FLASH__`  (Rack::Flash always seeds this, often to {})

If `__FLASH__` is non-empty (a pending flash message after a redirect), the cookie still gets written so the flash actually reaches the user on the next render.
