### PR TITLE
Send Cache-Control on cacheable read routes

### DIFF
--- a/lib/controllers/page_controller.rb
+++ b/lib/controllers/page_controller.rb
@@ -42,6 +42,26 @@ class PageController < BaseController
         starkast? ? "s" : "u",
       ].join("-")
     end
+
+    # Anonymous views are safe to cache in shared caches (nginx in front of
+    # the app, browser): the rendered HTML doesn't include any per-user data
+    # in the body. `no-cache` makes the browser revalidate every navigation
+    # so the moment a visitor logs in, the next page load sees fresh chrome
+    # — revalidation is cheap thanks to the ETag (304 with no body).
+    # `s-maxage` controls shared caches (nginx); 10 minutes is the default
+    # freshness window before nginx revalidates upstream.
+    #
+    # Authed views render edit/admin links and the current user, so they
+    # must never end up in a shared cache and must not be stored locally
+    # either (a browser-bookmarked authed page after logout would otherwise
+    # flash admin chrome before re-render).
+    def cache_for_audience
+      if logged_in?
+        cache_control :private, no_store: true
+      else
+        cache_control :public, :no_cache, s_maxage: 600
+      end
+    end
   end
 
   get '/' do
@@ -58,6 +78,7 @@ class PageController < BaseController
     end
 
     @page_title = @page.title
+    cache_for_audience
 
     # Skipped for the empty-wiki fallback (Page.new has no sha1); that
     # response is cheap to render anyway.
@@ -73,6 +94,7 @@ class PageController < BaseController
       .order(:title_char, :title)
       .with_concealed_if(starkast?)
       .to_hash_groups(:title_char)
+    cache_for_audience
     haml :index
   end
 
@@ -85,6 +107,7 @@ class PageController < BaseController
       .eager_graph(:author)
       .add_graph_aliases(date: [:pages, :date, Sequel.lit("DATE(updated_on)")])
       .to_hash_groups(:date)
+    cache_for_audience
     haml :latest
   end
 
@@ -257,6 +280,7 @@ class PageController < BaseController
     redirect "new/#{slug}" unless @page
     @page_title = @page.title
     restrict_concealed(@page)
+    cache_for_audience
     etag_for_page(@page)
     haml :show
   end
@@ -266,6 +290,7 @@ class PageController < BaseController
     redirect "#{slug}" unless @page
     @page_title = "#{@page.title} (#{revision})"
     restrict_concealed(@page)
+    cache_for_audience
     haml :show
   end
 

--- a/test/integration/app_logged_in_test.rb
+++ b/test/integration/app_logged_in_test.rb
@@ -40,6 +40,13 @@ class AppLoggedInTest < Minitest::Test
       "logged-in responses must continue to write Set-Cookie"
   end
 
+  def test_logged_in_page_view_sends_private_no_store_cache_control
+    get "/#{CGI.escape(@page.slug)}"
+    cc = last_response.headers["Cache-Control"].to_s
+    assert_includes cc, "private"
+    assert_includes cc, "no-store"
+  end
+
   def test_create_page
     title = "Foo Bar Åäö"
     post "/new", title:, content: "foo bar baz"

--- a/test/integration/app_not_logged_in_test.rb
+++ b/test/integration/app_not_logged_in_test.rb
@@ -95,6 +95,25 @@ class AppNotLoggedInTest < Minitest::Test
     extras&.each(&:destroy)
   end
 
+  def test_anonymous_page_view_sends_revalidating_cache_control
+    get "/#{CGI.escape(@page.slug)}"
+    cc = last_response.headers["Cache-Control"].to_s
+    assert_includes cc, "public"
+    # no-cache forces browser revalidation on every navigation so a fresh
+    # login-state chrome shows up immediately rather than after max-age expires.
+    assert_includes cc, "no-cache"
+    # s-maxage lets nginx (shared cache) hold the response longer than the
+    # browser; revalidation against the upstream ETag stays cheap.
+    assert_includes cc, "s-maxage=600"
+  end
+
+  def test_anonymous_index_sends_public_cache_control
+    get "/list"
+    cc = last_response.headers["Cache-Control"].to_s
+    assert_includes cc, "public"
+    assert_includes cc, "no-cache"
+  end
+
   def test_page
     get "/#{CGI.escape(@page.slug)}"
     assert last_response.body.include?(@page_title)


### PR DESCRIPTION
Anonymous responses for `/`, `/list`, `/latest`, `/:slug` and `/:slug/:revision` render only public content. Send:

    Cache-Control: public, no-cache, s-maxage=600

`no-cache` makes the browser revalidate every navigation. That's cheap because of the ETag from #947 — 304 with no body when nothing has changed — and it means the chrome (login link vs username, edit buttons etc.) updates the moment a visitor logs in or out, instead of going stale for a `max-age` window.

`s-maxage=600` is ignored by browsers but honored by shared caches, so nginx in front can hold the response for 10 minutes between upstream revalidations.

Authenticated responses render edit links and the current user, so they must never end up in a shared cache and shouldn't be persisted in the browser either:

    Cache-Control: private, no-store

Helper `cache_for_audience` in `PageController` selects between the two based on `logged_in?`. Tests pin both headers for anon and authed.

Routes intentionally not touched: `/search` (per-query, low reuse), `/new*` and `/:slug/edit` (write paths, redirect anon). `/:slug/uploads/:id/*` already sets its own `Cache-Control` with `:private` for concealed pages.

Towards #943.