### PR TITLE
Don't skip Set-Cookie when the session was populated on entry

### DIFF
--- a/lib/controllers/base_controller.rb
+++ b/lib/controllers/base_controller.rb
@@ -43,15 +43,28 @@ class BaseController < Sinatra::Base
   # Treat a session containing only these (and an empty __FLASH__) as empty.
   SESSION_NOISE_KEYS = %w[session_id __FLASH__].freeze
 
+  def session_has_real_data?
+    data = session.to_hash.reject { |k, _| SESSION_NOISE_KEYS.include?(k.to_s) }
+    return true unless data.empty?
+    flash = session["__FLASH__"]
+    flash.is_a?(Hash) && flash.any?
+  end
+
+  before do
+    # Snapshot whether the request *arrived* with a populated session so the
+    # after-filter can tell anonymous-throughout (skip the cookie, lets nginx
+    # cache) apart from logout-this-request (must write a fresh cookie to
+    # overwrite the browser's signed login cookie — see `/authorize/reset`).
+    @session_had_real_data_on_entry = session_has_real_data?
+  end
+
   after do
     session_options = request.env["rack.session.options"]
     next unless session_options
+    next if @session_had_real_data_on_entry
+    next if session_has_real_data?
 
-    data = session.to_hash.reject { |k, _| SESSION_NOISE_KEYS.include?(k.to_s) }
-    flash = session["__FLASH__"]
-    has_pending_flash = flash.is_a?(Hash) && flash.any?
-
-    session_options[:skip] = true if data.empty? && !has_pending_flash
+    session_options[:skip] = true
   end
 
   helpers do

--- a/test/integration/app_logged_in_test.rb
+++ b/test/integration/app_logged_in_test.rb
@@ -40,6 +40,20 @@ class AppLoggedInTest < Minitest::Test
       "logged-in responses must continue to write Set-Cookie"
   end
 
+  def test_logout_writes_session_cookie_to_overwrite_login_cookie
+    # Regression: the skip-empty-session after-filter must NOT trigger when
+    # the request arrived with a populated session — otherwise GET
+    # /authorize/reset clears the in-memory session but writes no Set-Cookie,
+    # so the browser keeps the original signed login cookie and stays logged
+    # in across the redirect-back.
+    get "/authorize/reset"
+
+    assert_equal 302, last_response.status
+    set_cookie = last_response.headers["Set-Cookie"].to_s
+    assert_match(/^wikimum_session=/, set_cookie,
+      "logout must overwrite the existing wikimum_session cookie, got: #{set_cookie.inspect}")
+  end
+
   def test_logged_in_page_view_sends_private_no_store_cache_control
     get "/#{CGI.escape(@page.slug)}"
     cc = last_response.headers["Cache-Control"].to_s


### PR DESCRIPTION
The after-filter added in #948 sets `:skip = true` on rack-session whenever the session hash is empty at the end of the request. That made GET /authorize/reset (logout) a no-op from the browser's perspective: `session.clear` empties the session in memory, the after-filter then suppresses Set-Cookie, and the browser keeps the original signed `wikimum_session=<login>` cookie. On the next request the server decrypts it back into a populated session and the user appears logged in again — confirmed end-to-end against puma + curl.

Snapshot whether the session arrived with real data in a `before` filter and only set `:skip` when it was empty on entry AND stays empty. Anonymous-throughout requests still skip the cookie (so nginx's proxy_cache can fill); login/logout transitions go through rack-session's normal commit path so the browser cookie is replaced.