### PR TITLE
Delete the wikimum_session cookie on logout

### DIFF
--- a/lib/controllers/authorize_controller.rb
+++ b/lib/controllers/authorize_controller.rb
@@ -33,6 +33,16 @@ class AuthorizeController < BaseController
   get '/reset' do
     session.clear
 
+    # Clearing the session in memory isn't enough: rack-session would still
+    # write a fresh signed `wikimum_session=<empty>` cookie on the way out,
+    # which keeps tripping `proxy_cache_bypass $cookie_wikimum_session` in
+    # nginx for every subsequent anonymous request (X-Cache-Status: BYPASS)
+    # until the cookie expires a year later. Tell rack-session to skip the
+    # commit and write an explicit deletion cookie instead, so the browser
+    # actually drops it and post-logout requests can HIT the page cache.
+    request.env["rack.session.options"][:drop] = true
+    response.delete_cookie('wikimum_session', path: '/')
+
     redirect back
   end
 

--- a/test/integration/app_logged_in_test.rb
+++ b/test/integration/app_logged_in_test.rb
@@ -40,18 +40,21 @@ class AppLoggedInTest < Minitest::Test
       "logged-in responses must continue to write Set-Cookie"
   end
 
-  def test_logout_writes_session_cookie_to_overwrite_login_cookie
-    # Regression: the skip-empty-session after-filter must NOT trigger when
-    # the request arrived with a populated session — otherwise GET
-    # /authorize/reset clears the in-memory session but writes no Set-Cookie,
-    # so the browser keeps the original signed login cookie and stays logged
-    # in across the redirect-back.
+  def test_logout_deletes_the_session_cookie
+    # GET /authorize/reset must send a *deletion* Set-Cookie (empty value +
+    # past expiry), not just a fresh signed empty session. Otherwise the
+    # browser keeps a non-empty wikimum_session value, which keeps tripping
+    # nginx's `proxy_cache_bypass $cookie_wikimum_session` on every
+    # subsequent anonymous request for up to a year (X-Cache-Status: BYPASS
+    # instead of HIT).
     get "/authorize/reset"
 
     assert_equal 302, last_response.status
     set_cookie = last_response.headers["Set-Cookie"].to_s
-    assert_match(/^wikimum_session=/, set_cookie,
-      "logout must overwrite the existing wikimum_session cookie, got: #{set_cookie.inspect}")
+    assert_match(/^wikimum_session=;/, set_cookie,
+      "logout cookie should be the deletion form (empty value), got: #{set_cookie.inspect}")
+    assert_match(/expires=Thu, 01 Jan 1970/i, set_cookie,
+      "logout cookie should expire in the past so the browser drops it, got: #{set_cookie.inspect}")
   end
 
   def test_logged_in_page_view_sends_private_no_store_cache_control


### PR DESCRIPTION
After #950, GET /authorize/reset clears the session and writes a fresh signed `wikimum_session=<empty>` cookie. The browser stores it and keeps sending it back, which trips nginx's
`proxy_cache_bypass $cookie_wikimum_session` on every subsequent anonymous request — X-Cache-Status: BYPASS instead of HIT for up to a year, even though the user is logged out.

Fix it by telling rack-session to drop the session (`:drop = true`, which makes Rack::Session::Cookie#delete_session return nil so commit_session writes nothing) and emitting an explicit Set-Cookie: wikimum_session=; max-age=0; expires=Thu, 01 Jan 1970... The browser deletes the cookie, the next request goes through nginx with no `$cookie_wikimum_session` to bypass on, and the page cache serves the anonymous body.

Verified end-to-end against puma + curl:

- login: Set-Cookie with signed login session
- logout: Set-Cookie with empty value + expires=Thu, 01 Jan 1970
- curl cookie jar no longer contains wikimum_session
- subsequent GET / has no cookie, no Set-Cookie
