### PR TITLE
Stop flaky Chromium launch in CI

### DIFF
--- a/test/browser/link_titles_selection_test.js
+++ b/test/browser/link_titles_selection_test.js
@@ -21,10 +21,24 @@ describe('Link titles selection feature', { timeout: 30000 }, () => {
   let page;
 
   before(async () => {
+    // `--disable-dev-shm-usage` is required on GitHub Actions runners:
+    // /dev/shm there is ~64 MB, which makes Chromium crash silently during
+    // startup. The launcher then hits its 30 s "waiting for WS endpoint"
+    // timeout, exactly as we kept seeing in CI. `--disable-gpu` is the
+    // standard headless-on-Linux companion.
     browser = await puppeteer.launch({
       executablePath: '/usr/bin/chromium',
       headless: true,
-      args: ['--no-sandbox', '--disable-setuid-sandbox']
+      // Surface Chromium's own stderr in the test runner log so the next
+      // time it dies during startup we see the real error, not just our
+      // own launch timeout.
+      dumpio: true,
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage',
+        '--disable-gpu',
+      ],
     });
     page = await browser.newPage();
 


### PR DESCRIPTION
Browser tests have been failing on roughly half of CI runs with:

```
TimeoutError: Timed out after 30000 ms while waiting for the WS endpoint URL to appear in stdout!
    at ChromeLauncher.launch (puppeteer-core/.../BrowserLauncher.js:188)
```

`Starting server on port 9393...` prints right before, so the Sinatra side is fine — Chromium is starting and dying silently before it gets to log its DevTools WS URL.

On GitHub Actions Linux runners `/dev/shm` is ~64 MB. Chromium uses shared memory for several subsystems and crashes during startup when that runs out. The standard workaround is `--disable-dev-shm-usage`, which makes it back the same memory with `/tmp` instead. Adding it (plus `--disable-gpu`, the usual companion for headless on a GPU-less box).

Also flip `dumpio: true` so the next time Chromium dies during startup we see its own stderr in the test runner log, not just our launcher timeout.