### PR TITLE
Look up page slugs case-insensitively

### DIFF
--- a/lib/controllers/page_controller.rb
+++ b/lib/controllers/page_controller.rb
@@ -180,7 +180,7 @@ class PageController < BaseController
   end
 
   get '/:slug/edit' do
-    @page = Page.find(slug: slug)
+    @page = Page.with_slug(slug).first
     unless logged_in?
       flash[:error] = "Not authorized to edit!"
       if @page
@@ -207,7 +207,7 @@ class PageController < BaseController
   get '/:slug/uploads/:id/:filename?' do |_, id, _|
     upload = Upload[id.to_i]
     halt 404, "Upload not found" unless upload
-    halt 404, "Upload not found" unless upload.page.slug == slug
+    halt 404, "Upload not found" unless upload.page.slug.downcase == slug
     halt 404, "Upload not found" if upload.page.concealed && !starkast?
 
     # uploads to concealed pages should only be cached in a private cache,
@@ -221,7 +221,7 @@ class PageController < BaseController
   end
 
   get '/:slug/uploads' do
-    page = Page.find(slug: slug)
+    page = Page.with_slug(slug).first
     halt 404, "Page not found" unless page
     restrict_concealed(page)
 
@@ -232,7 +232,7 @@ class PageController < BaseController
   post '/:slug/uploads' do
     halt 401, "Not authorized" unless logged_in?
 
-    page = Page.find(slug: slug)
+    page = Page.with_slug(slug).first
     halt 404, "Page not found" unless page
     restrict_concealed(page)
 
@@ -257,7 +257,7 @@ class PageController < BaseController
 
     upload = Upload[id.to_i]
     halt 404, "Upload not found" unless upload
-    halt 404, "Upload not found" unless upload.page.slug == slug
+    halt 404, "Upload not found" unless upload.page.slug.downcase == slug
     restrict_concealed(upload.page)
 
     upload.destroy
@@ -274,7 +274,7 @@ class PageController < BaseController
     @page = Page
       .select(:id, :slug, :title, :concealed, :revision, :updated_on, :compiled_content, :author_id, :sha1)
       .eager_graph(:author)
-      .where(slug: slug)
+      .with_slug(slug)
       .limit(1)
       .all
       .first
@@ -287,7 +287,7 @@ class PageController < BaseController
   end
 
   get '/:slug/:revision' do |_, revision|
-    @page = Revision.where(slug: slug, revision: revision.to_i).first
+    @page = Revision.with_slug(slug).where(revision: revision.to_i).first
     redirect "#{slug}" unless @page
     @page_title = "#{@page.title} (#{revision})"
     restrict_concealed(@page)
@@ -298,7 +298,7 @@ class PageController < BaseController
   post '/:slug' do
     halt 400, "Missing title" if params[:title].to_s.empty?
 
-    page = Page.find(slug: slug)
+    page = Page.with_slug(slug).first
     restrict_concealed(page)
     page.revise!
     page.set_fields(params, %i(title content description comment))
@@ -309,7 +309,7 @@ class PageController < BaseController
   end
 
   post '/:slug/conceal' do
-    page = Page.find(slug: slug)
+    page = Page.with_slug(slug).first
     restrict_concealed(page)
 
     # intentionally avoid Page save hook

--- a/lib/models/page.rb
+++ b/lib/models/page.rb
@@ -16,6 +16,15 @@ class Page < Sequel::Model
       self.exclude(concealed: true)
     end
 
+    # Look up by slug case-insensitively. The route normalizes the request
+    # slug through Slug.slugify (which lowercases), but pages created before
+    # Slug.slugify started downcasing preserved their title's casing in the
+    # slug column — see GitHub issue #138. Comparing on `lower(slug)` keeps
+    # those legacy rows reachable.
+    def with_slug(slug)
+      self.where(Sequel.function(:lower, :slug) => slug)
+    end
+
     def search(query)
       terms = query.to_s.strip.split
 

--- a/lib/models/revision.rb
+++ b/lib/models/revision.rb
@@ -5,6 +5,12 @@ class Revision < Sequel::Model
   many_to_one :page
   many_to_one :author, class: :User
 
+  dataset_module do
+    def with_slug(slug)
+      self.where(Sequel.function(:lower, :slug) => slug)
+    end
+  end
+
   def revisions
     self.page.revisions
   end

--- a/test/integration/app_not_logged_in_test.rb
+++ b/test/integration/app_not_logged_in_test.rb
@@ -204,6 +204,24 @@ class AppNotLoggedInTest < Minitest::Test
     assert_includes last_response.body, @page_title
   end
 
+  def test_revision_lookup_handles_legacy_mixed_case_slug
+    # Revise! copies the page's slug into the revision row, so revisions of
+    # legacy pages inherited the same mixed-case slug as the page itself.
+    # /:slug/:revision must match them case-insensitively too.
+    @page.revise!
+    revision = Revision.where(page_id: @page.id, revision: 1).first
+    revision.this.update(slug: "Öppettider")
+
+    get "/#{CGI.escape("Öppettider")}/1"
+
+    assert last_response.ok?,
+      "GET /Öppettider/1 should find a revision stored with legacy uppercase slug, " \
+      "got #{last_response.status} -> #{last_response["Location"].inspect}"
+    assert_includes last_response.body, @page_title
+  ensure
+    revision&.destroy
+  end
+
   def test_new
     get "/new"
 

--- a/test/integration/app_not_logged_in_test.rb
+++ b/test/integration/app_not_logged_in_test.rb
@@ -188,6 +188,22 @@ class AppNotLoggedInTest < Minitest::Test
     assert_equal "/new/#{random_slug}", URI(redirect_location).path
   end
 
+  def test_page_lookup_handles_legacy_mixed_case_slug
+    # Pages created before Slug.slugify started downcasing kept their title's
+    # original casing in the slug column. The route normalizes the request
+    # slug through Slug.slugify (which lowercases), so a stored slug like
+    # 'Öppettider' would never match and the visitor was redirected to
+    # /new/öppettider. See GitHub issue #138.
+    @page.this.update(slug: "Öppettider")
+
+    get "/#{CGI.escape("Öppettider")}"
+
+    assert last_response.ok?,
+      "GET /Öppettider should find a page stored with legacy uppercase slug, " \
+      "got #{last_response.status} -> #{last_response["Location"].inspect}"
+    assert_includes last_response.body, @page_title
+  end
+
   def test_new
     get "/new"
 


### PR DESCRIPTION
Pages created before commit b9607a2 (2013) preserved the title's original casing in the slug column. The /:slug route normalizes the request slug through Slug.slugify (which downcases), so a stored slug like 'Öppettider' never matched and the visitor was redirected to /new/öppettider.

Compare on LOWER(slug) via a `with_slug` dataset method on Page and Revision, and downcase the stored side in the two upload guards that checked `upload.page.slug == slug`.

Fixes #138.