### PR TITLE
Remove dead 30s wait in browser test login

### DIFF
--- a/test/browser/link_titles_selection_test.js
+++ b/test/browser/link_titles_selection_test.js
@@ -42,10 +42,8 @@ describe('Link titles selection feature', { timeout: 30000 }, () => {
     });
     page = await browser.newPage();
 
-    // Login via dev endpoint
+    // Login via dev endpoint; goto follows the 302 and stores the session cookie before resolving
     await page.goto(`${TEST_URL}/authorize/dev`);
-    // Wait for redirect to complete
-    await page.waitForNavigation({ waitUntil: 'networkidle0' }).catch(() => {});
   });
 
   after(async () => {


### PR DESCRIPTION
goto already follows the 302 to / and stores the session cookie before resolving, so the trailing waitForNavigation never sees a second navigation and burned the full 30s default timeout every run.


- bundle exec rake test:browser: 34s to 9s
- browser job total: ~55s to 34s