### PR TITLE
Run CodeQL on ubuntu-latest

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
ubuntu-slim is single-core with no pre-cached CodeQL bundle, so every run re-downloads the bundle (~20s) and analyzes single-threaded. ubuntu-latest ships the bundle in the toolcache and parallelizes analysis, cutting the longest CI gate by roughly 40-60s.

- total: 129-194s to 49s
- Initialize CodeQL tools: ~47s to 11s (bundle served from the runner toolcache instead of re-downloading - this part is deterministic and repeatable)
- Perform CodeQL Analysis: 71-132s to 31s (multi-core)