### PR TITLE
Run push CI only on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     types:
       - opened


### PR DESCRIPTION
A commit on a branch with an open PR fired both the push and the pull_request event, running the full CI matrix twice. Restrict push to main so feature branches run once via pull_request; main still runs on push so the Fly deploy trigger is unaffected.