### PR TITLE
Design layout stability

### DIFF
--- a/public/stylesheets/default.css
+++ b/public/stylesheets/default.css
@@ -109,7 +109,7 @@ hr {
 #login          { position: absolute; right: 1em; top: 1em; margin: 0.6em; }
 #administration { position: absolute; right: 1em; top: 4em; }
 #message        { margin: 1.5em 0 1em 0; font-size: 1.6em; }
-#sub-navigation { height: 1.5em; }
+#sub-navigation { height: 3em; overflow: hidden; }
 #actions        { float: left; }
 #footer         { margin: 2em 0 0 0; }
 
@@ -227,6 +227,9 @@ a.page-link#navigation-selected { background: #FFC; }
 h1.logo    { font-size: 5.8em; margin: 0; padding: 0; display: inline; }
 h1.title   { margin-top: 0; padding-top: 0; }
 h1.title a { text-decoration: none; }
+
+/* Same page-title height on every page, whether the view uses h1 or h1.title */
+#content > h1:first-child { margin-top: 0; padding-top: 0; }
 
 /* Misc */
 h3 small {

--- a/public/stylesheets/default.css
+++ b/public/stylesheets/default.css
@@ -108,7 +108,6 @@ hr {
 #container-lg   { margin: 4em auto 0 auto; text-align: left; }
 #login          { position: absolute; right: 1em; top: 1em; margin: 0.6em; }
 #administration { position: absolute; right: 1em; top: 4em; }
-#message        { margin: 1.5em 0 1em 0; font-size: 1.6em; }
 #sub-navigation { height: 3em; overflow: hidden; }
 #actions        { float: left; }
 #footer         { margin: 2em 0 0 0; }
@@ -245,7 +244,32 @@ span.abort  { font-size: 1.6em; }
 
 div.add_permission_link { font-size: 1.6em; margin: 0.5em 0 0.5em 0; }
 
-/* Messages */
+/* Messages — a floating toast so they never shift the page layout */
+#message {
+  position: fixed;
+  top: 1em;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 150;
+  max-width: 90%;
+  font-size: 1.6em;
+  transition: opacity 0.4s ease;
+}
+#message.hide { opacity: 0; }
+
+#message span {
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+  box-sizing: border-box;
+  margin: 0 auto 0.4em auto;
+  padding: 0.5em 0.85em;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  cursor: pointer;
+}
+#message span:last-child { margin-bottom: 0; }
+
 span.message { background: #FFC; }
 span.confirm { background: #e3ffb7; }
 span.notice  { background: #cbebff; }

--- a/public/stylesheets/default.css
+++ b/public/stylesheets/default.css
@@ -5,7 +5,8 @@
 /* Reset and set some "defaults" */
 
 *    { font-size: 100.01%; margin: 0; padding: 0; }
-html { font-size: 62.5%; }
+/* Always reserve the scrollbar's space so page length doesn't shift the layout */
+html { font-size: 62.5%; scrollbar-gutter: stable; }
 body {
   margin: 2em 5em;
   font-family: Arial;

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -131,3 +131,14 @@
           this.classList.remove('visible');
         }
       });
+
+      (function() {
+        var message = document.getElementById('message');
+        if (!message) return;
+        function dismiss() {
+          message.classList.add('hide');
+          setTimeout(function() { message.remove(); }, 400);
+        }
+        message.addEventListener('click', dismiss);
+        setTimeout(dismiss, 5000);
+      })();

--- a/views/layouts/_flash.haml
+++ b/views/layouts/_flash.haml
@@ -1,8 +1,9 @@
-#message
-  - if flash[:error]
-    %span.error
-      != flash[:error]
-  -if flash[:notice]
-    %span.notice= flash[:notice]
-  - if flash[:confirm]
-    %span.confirm= flash[:confirm]
+- if flash[:error] || flash[:notice] || flash[:confirm]
+  #message
+    - if flash[:error]
+      %span.error
+        != flash[:error]
+    - if flash[:notice]
+      %span.notice= flash[:notice]
+    - if flash[:confirm]
+      %span.confirm= flash[:confirm]

--- a/views/page/index.haml
+++ b/views/page/index.haml
@@ -1,9 +1,10 @@
+%h1 Innehållsförteckning
+
 %ul#sections
   - @page_groups.each do |char, _|
     %li
       %a{ href: "\##{char}" }= char
 
-%h1 Innehållsförteckning
 - @page_groups.each do |char, pages|
   %h2
     %a{ href: "\##{char}", name: char }= char


### PR DESCRIPTION
Minor tweaks to make sure layout is stable when navigation, this is how it was originally designed.

---

Before/After pairs:

<img width="1200" height="470" alt="before_latest" src="https://github.com/user-attachments/assets/c8c80376-828c-4b60-b266-42757998abe0" />
<img width="1200" height="470" alt="after_latest" src="https://github.com/user-attachments/assets/deff5bb2-7750-4ce8-aa81-020c189fec08" />


---

<img width="1200" height="470" alt="before_list" src="https://github.com/user-attachments/assets/6502b430-06b9-43f0-bada-c1db995eb444" />
<img width="1200" height="470" alt="after_list" src="https://github.com/user-attachments/assets/6487271c-b10e-4e6d-955e-68d17ec5fa72" />


---

<img width="1200" height="470" alt="before_search" src="https://github.com/user-attachments/assets/28d1d8cb-0037-4a4e-a66f-3fe03fddf8f9" />
<img width="1200" height="470" alt="after_search" src="https://github.com/user-attachments/assets/8eaf59da-e6b1-49c5-bf6e-5ee4eb624cd5" />


---

<img width="1200" height="470" alt="before_slug" src="https://github.com/user-attachments/assets/bb75d608-a088-4a83-a5a2-f6edd127cae7" />
<img width="1200" height="470" alt="after_slug" src="https://github.com/user-attachments/assets/0fa7926e-5071-404e-9ff1-771faffdde96" />

