### PR TITLE
Don't cache responses that render a flash message

### DIFF
--- a/lib/controllers/page_controller.rb
+++ b/lib/controllers/page_controller.rb
@@ -42,6 +42,7 @@ class PageController < BaseController
         page.concealed ? "c" : "x",
         logged_in? ? "a" : "p",
         starkast? ? "s" : "u",
+        flash.keys.any? ? "f" : "n",
       ].join("-")
     end
 
@@ -58,7 +59,7 @@ class PageController < BaseController
     # either (a browser-bookmarked authed page after logout would otherwise
     # flash admin chrome before re-render).
     def cache_for_audience
-      if logged_in?
+      if logged_in? || flash.keys.any?
         cache_control :private, no_store: true
       else
         cache_control :public, :no_cache, s_maxage: 600

--- a/test/integration/app_not_logged_in_test.rb
+++ b/test/integration/app_not_logged_in_test.rb
@@ -114,6 +114,16 @@ class AppNotLoggedInTest < Minitest::Test
     assert_includes cc, "no-cache"
   end
 
+  def test_flashed_page_is_not_cacheable
+    get "/new"
+    follow_redirect!
+
+    assert last_response.ok?
+    assert_includes last_response.body, "logged in to create a new page"
+    assert_includes last_response.headers["Cache-Control"].to_s, "no-store",
+      "a response showing a flash must not be cacheable"
+  end
+
   def test_page
     get "/#{CGI.escape(@page.slug)}"
     assert last_response.body.include?(@page_title)


### PR DESCRIPTION
A one-shot flash was rendered into a response that stayed HTTP-cacheable (public, no-cache) with an ETag that ignored the flash. After the flash was cleared server-side, the browser kept revalidating, got 304s (the ETag matched because it didn't depend on the flash), and re-served the cached body with the stale message on every reload — e.g. clicking "create new page" while logged out left "must be logged in" stuck.

Send Cache-Control: private, no-store whenever a flash is shown so the body is never stored, and add a flash bucket to the page ETag so a flashed body and a clean body never share a cache entry. The ETag change also evicts already-stuck browser caches on the next reload.