### PR TITLE
Install pg_dump 18 from PGDG to match the prod server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,15 @@ FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base
 # The app lives here
 WORKDIR /app
 
-# Install base packages
+# Install pg_dump 18 from PGDG; it must be >= the production server's major version.
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y \
-    curl \
-    postgresql-client
+    apt-get install --no-install-recommends -y curl ca-certificates && \
+    curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+      -o /usr/share/keyrings/pgdg.asc && \
+    echo "deb [signed-by=/usr/share/keyrings/pgdg.asc] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
+      > /etc/apt/sources.list.d/pgdg.list && \
+    apt-get update -qq && \
+    apt-get install --no-install-recommends -y postgresql-client-18
 
 # Set production environment
 ENV BUNDLE_DEPLOYMENT="1" \


### PR DESCRIPTION
The production Postgres server is on 18, but the image shipped Debian's v17 client. pg_dump refuses to dump a server newer than itself, so the nightly /.backup raised and returned 500. Add the PGDG repo and install postgresql-client-18.