### PR TITLE
Fix broken backups by owning the dump file lifetime

### DIFF
--- a/lib/controllers/backup_controller.rb
+++ b/lib/controllers/backup_controller.rb
@@ -2,11 +2,14 @@
 
 require "base64"
 require "fileutils"
-require "tempfile"
+require "securerandom"
 
 class BackupController < Sinatra::Base
+  STALE_DUMP_AGE = 3600 # seconds
+
   post "/" do
-    dump_path    = create_sql_tempfile("dump").path
+    sweep_stale_dumps
+    dump_path    = create_dump_path
     rel_path     = dump_path.split(backup_tmpdir).last
     encoded_path = Base64.urlsafe_encode64(rel_path)
 
@@ -52,10 +55,22 @@ class BackupController < Sinatra::Base
       nil
     end
 
-    def create_sql_tempfile(filename)
-      tmpdir = FileUtils.mkdir_p(backup_tmpdir).first
+    # Own the path outright; Tempfile's finalizer would delete it before download.
+    def create_dump_path
+      FileUtils.mkdir_p(backup_tmpdir)
 
-      Tempfile.new([filename, ".sql"], tmpdir)
+      File.join(backup_tmpdir, "dump-#{SecureRandom.uuid}.sql")
+    end
+
+    # Replaces Tempfile's finalizer: drop dumps left behind by earlier backups.
+    def sweep_stale_dumps
+      cutoff = Time.now - STALE_DUMP_AGE
+
+      Dir.glob(File.join(backup_tmpdir, "dump-*.sql")).each do |path|
+        File.delete(path) if File.mtime(path) < cutoff
+      rescue Errno::ENOENT
+        nil
+      end
     end
   end
 end

--- a/test/integration/app_backup_test.rb
+++ b/test/integration/app_backup_test.rb
@@ -67,6 +67,44 @@ class AppBackupTest < Minitest::Test
     assert_backup(maintenance_mode: true)
   end
 
+  # A GC pass between the backup and download requests must not delete the dump.
+  def test_backup_survives_gc_before_download
+    username, password = ["user", "pass"]
+
+    ClimateControl.modify(BACKUP_USER: username, BACKUP_PASSWORD: password) do
+      basic_authorize username, password
+      post "/.backup"
+
+      GC.start
+
+      follow_redirect!
+
+      body = last_response.body.force_encoding(Encoding::UTF_8)
+      assert_equal 200, last_response.status
+      assert_match(/#{@page_title}/, body)
+    end
+  end
+
+  # Each backup must sweep stale dumps so they do not accumulate on disk.
+  def test_backup_sweeps_stale_dumps
+    backup_dir = File.join(Dir.tmpdir, "wiki_backup")
+    FileUtils.mkdir_p(backup_dir)
+    stale = File.join(backup_dir, "dump-#{SecureRandom.uuid}.sql")
+    File.write(stale, "old dump")
+    File.utime(Time.now - 7200, Time.now - 7200, stale)
+
+    username, password = ["user", "pass"]
+    ClimateControl.modify(BACKUP_USER: username, BACKUP_PASSWORD: password) do
+      basic_authorize username, password
+      post "/.backup"
+      follow_redirect!
+
+      assert_equal 200, last_response.status
+    end
+
+    refute File.exist?(stale), "expected stale dump to be swept"
+  end
+
   def test_download_rejects_path_traversal
     backup_dir = File.join(Dir.tmpdir, "wiki_backup")
     FileUtils.mkdir_p(backup_dir)


### PR DESCRIPTION
Tempfile's finalizer deleted the dump once the object was GC'd, which can happen between the backup and download requests in production, so the download 404'd. Own the path directly and sweep stale dumps to replace the cleanup Tempfile used to provide.