### PR TITLE
Only redirect back to our own host

### DIFF
--- a/lib/controllers/authorize_controller.rb
+++ b/lib/controllers/authorize_controller.rb
@@ -61,7 +61,7 @@ class AuthorizeController < BaseController
     request.env["rack.session.options"][:drop] = true
     response.delete_cookie('wikimum_session', path: '/')
 
-    redirect back
+    redirect safe_back
   end
 
   get '/dev' do

--- a/lib/controllers/base_controller.rb
+++ b/lib/controllers/base_controller.rb
@@ -2,6 +2,7 @@
 
 require 'rack-flash'
 require 'rack/protection'
+require 'uri'
 require 'sinatra/haml_helpers'
 require 'sinatra/reloader'
 require 'tilt/haml'
@@ -83,13 +84,22 @@ class BaseController < Sinatra::Base
       Rack::Protection::AuthenticityToken.token(session)
     end
 
+    # Only follow the Referer when it points at our own host, never off-site.
+    def safe_back
+      referrer = request.referrer
+      return "/" unless referrer && URI.parse(referrer).host == request.host
+      referrer
+    rescue URI::InvalidURIError
+      "/"
+    end
+
     def prevent_unauthorized_modifications
       return if request.request_method == "GET"
 
       unless logged_in?
         flash[:error] = "Not authorized!"
 
-        redirect back
+        redirect safe_back
       end
 
       halt 403, "Forbidden" unless CSRF.accepts?(request.env)

--- a/lib/controllers/page_controller.rb
+++ b/lib/controllers/page_controller.rb
@@ -14,7 +14,7 @@ class PageController < BaseController
       if page.concealed?
         flash[:error] = "Not authorized!"
 
-        redirect back
+        redirect safe_back
       end
     end
 

--- a/test/integration/app_concealed_pages_test.rb
+++ b/test/integration/app_concealed_pages_test.rb
@@ -45,6 +45,26 @@ class AppConcealedPagesTest < Minitest::Test
     assert last_response.ok?
   end
 
+  def test_concealed_does_not_redirect_to_external_referrer
+    header "Referer", "https://github.com/Starkast/wikimum/issues/6"
+
+    get "/#{@page.slug_for_uri}"
+
+    assert_equal 302, last_response.status
+    assert_equal "/", URI(last_response["Location"]).path,
+      "an off-site referrer must not be followed back; fall back to the front page"
+  end
+
+  def test_concealed_redirects_back_to_same_host_referrer
+    header "Referer", "http://#{current_session.default_host}/list"
+
+    get "/#{@page.slug_for_uri}"
+
+    assert_equal 302, last_response.status
+    assert_equal "/list", URI(last_response["Location"]).path,
+      "a same-host referrer is ours, so redirect back is honoured"
+  end
+
   def test_concealed_logged_in_as_starkast
     login_as_starkast
     get "/#{@page.slug_for_uri}"


### PR DESCRIPTION
`redirect back` followed the Referer header wherever it pointed, so an anonymous visitor opening a concealed page from an external link (e.g. a GitHub issue) got bounced straight back off-site, and the "Not authorized!" flash never rendered.